### PR TITLE
Desktop mode compatibility

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -16,7 +16,7 @@ module.exports = new Extension({
         // does this type of artwork need to be downloaded to the frame?
         'download': false,
         // how do start this type of artwork? currently two token replacements, $filepath and $url
-        'start_command': 'glslLoader $url',
+        'start_command': 'glslLoader $url --fullscreen',
         // how do we stop this type of artwork?
         'end_command': 'pkill glslViewer'
     }

--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,7 @@ if [ $os == "Linux" ]; then
             sudo apt-get install libegl1-mesa-dev libgbm-dev libgles2-mesa-dev
             git clone --depth=1 --branch=master http://github.com/patriciogonzalezvivo/glslViewer glslViewer
             cd glslViewer
-            make
+            make DRIVER=glfw
             sudo make install
         else
             sudo apt-get install glslviewer


### PR DESCRIPTION
Implements: https://github.com/OpenframeProject/Openframe-glslViewer/issues/11


TODO:
- [ ] Currently fails with "Package glfw3 was not found in the pkg-config search path."  On Pi 4B with Raspian OS.
Might be related to: https://github.com/patriciogonzalezvivo/glslViewer/issues/179
- [ ] keep console mode compatibility