### PR TITLE
fix 403 error

### DIFF
--- a/bin/glslLoader
+++ b/bin/glslLoader
@@ -19,6 +19,7 @@ if SHADER_PATH.isdigit():
 
 if SHADER_PATH.startswith('http'):
     http = urllib.URLopener()
+    http.addheaders = [('User-Agent', 'Mozilla/5.0')]
     http.retrieve(SHADER_PATH, TMP_SHD)
     SHADER_PATH=TMP_SHD
 


### PR DESCRIPTION
Many web services forbid access from Python urllib. (Especially for services that use Cloudflare).
So hosting methods for shaders are currently limited.

This problem can be fixed by making a change to the default header of urllib.